### PR TITLE
Improve concurrency

### DIFF
--- a/pkg/service/card/card.go
+++ b/pkg/service/card/card.go
@@ -3,7 +3,6 @@ package card
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"time"
 )
 
@@ -13,25 +12,23 @@ func GenerateNumbers(totalNumbers int, maxNumber int) ([]int, error) {
 		return nil, fmt.Errorf("Wrong totalNumbers: expected more than 0, got %d", totalNumbers)
 	}
 
-	ch := make(chan int, totalNumbers)
-	wg := &sync.WaitGroup{}
+	result := make([]int, totalNumbers)
+	ch := make(chan int)
 	rand.Seed(time.Now().UnixNano())
 	for i := 0; i < totalNumbers; i++ {
-		wg.Add(1)
-		go func(wg *sync.WaitGroup, ch chan<- int) {
-			defer wg.Done()
+		go func(ch chan<- int) {
 			// do hard random calculation work :-)
 			ch <- rand.Intn(maxNumber + 1)
-		}(wg, ch)
+		}(ch)
 	}
 
-	wg.Wait()
+	for i := 0; i < totalNumbers; {
+		select {
+		case result[i] = <-ch:
+			i++
+		}
+	}
 	close(ch)
-
-	result := make([]int, 0)
-	for number := range ch {
-		result = append(result, number)
-	}
 
 	return result, nil
 }

--- a/test/endpoints_test.go
+++ b/test/endpoints_test.go
@@ -29,7 +29,7 @@ func TestCard(t *testing.T) {
 
 			recorder := httptest.NewRecorder()
 			router := mux.NewRouter()
-			router.HandleFunc("/card", handler.Card)
+			router.HandleFunc(tt.route, handler.Card)
 			router.ServeHTTP(recorder, req)
 
 			if recorder.Code != tt.wantStatus {


### PR DESCRIPTION
1) Rewrote numbers generator without sync.WaitGroup
2) Fixed hardcoded route in endpoints test